### PR TITLE
make.py: minor correction for variant argument

### DIFF
--- a/make.py
+++ b/make.py
@@ -80,7 +80,7 @@ def main():
     soc_kwargs.update(with_jtagbone=False)
 
     if args.variant is not None:
-        soc_kwargs.update(cpu_variant=args.variant)
+        soc_kwargs.update(variant=args.variant)
     if args.sys_clk_freq is not None:
         soc_kwargs.update(sys_clk_freq=int(float(args.sys_clk_freq)))
 


### PR DESCRIPTION
With this minor change, I was able to get support for the arty-a7-100t board (a variant of arty).

The command to build was
```
./make.py --board=arty --variant=a7-100 --build --toolchain=symbiflow
```

Fixes #9

<img width="622" alt="Screen Shot 2022-08-13 at 12 33 15 PM" src="https://user-images.githubusercontent.com/983494/184502830-1ad1cd36-8fd2-4c6c-9c23-6a82e02fac16.png">

