### PR TITLE
add support for Lattice Crosslink-NX EVN

### DIFF
--- a/make.py
+++ b/make.py
@@ -49,12 +49,24 @@ class SDI_MIPI_Bridge(Board):
         prog = soc.platform.create_programmer(prog="ecpprog")
         prog.load_bitstream(filename)
 
+class LatticeCrosslinkNxEvn(Board):
+    def __init__(self):
+        from litex_boards.targets import lattice_crosslink_nx_evn
+        Board.__init__(self, lattice_crosslink_nx_evn.BaseSoC)
+        self.bitstream_name="lattice_crosslink_nx_evn"
+        self.bitstream_ext=".bit"
+
+    def load(self, soc, filename):
+        prog = soc.platform.create_programmer(prog="ecpprog")
+        prog.load_bitstream(filename)
+
 # Main ---------------------------------------------------------------------------------------------
 
 supported_boards = {
     # Xilinx
     "arty":         Arty,
     "sdi_mipi_bridge":     SDI_MIPI_Bridge,
+    "lattice_crosslink_nx_evn": LatticeCrosslinkNxEvn,
 }
 
 def main():


### PR DESCRIPTION
This is only working if also adding a "main_ram" section to the Crosslink-NX EVN board as it is done for the Antmicro SDI/MIPI board insofar.

I am working on getting flash support, as currently, the `shell_module` demo from LiteX fails to fit in the `main_ram` if sized as large as the SDI/MIPI board.

```
/usr/lib/gcc/riscv-none-elf/13.1.0/../../../../riscv-none-elf/bin/ld.bfd: zephyr/zephyr_pre0.elf section `text' will not fit in region `RAM'
/usr/lib/gcc/riscv-none-elf/13.1.0/../../../../riscv-none-elf/bin/ld.bfd: region `RAM' overflowed by 40700 bytes
```

Yet this works after small manual tuning from the generated overlay.config and overlay.dts. :)