### PR TITLE
SPI flash support to boot larger firmwares

### DIFF
--- a/make.py
+++ b/make.py
@@ -25,6 +25,10 @@ class Board:
     def flash(self):
         raise NotImplementedError
 
+#---------------------------------------------------------------------------------------------------
+# Xilinx Boards
+#---------------------------------------------------------------------------------------------------
+
 # Arty support -------------------------------------------------------------------------------------
 
 class Arty(Board):
@@ -38,6 +42,12 @@ class Arty(Board):
         self.bitstream_name="digilent_arty"
         self.bitstream_ext=".bit"
 
+#---------------------------------------------------------------------------------------------------
+# Lattice Boards
+#---------------------------------------------------------------------------------------------------
+
+# Antmicro SDI/MIPI Video Converter support --------------------------------------------------------
+
 class SDI_MIPI_Bridge(Board):
     def __init__(self):
         from litex_boards.targets import antmicro_sdi_mipi_video_converter
@@ -49,12 +59,16 @@ class SDI_MIPI_Bridge(Board):
         prog = soc.platform.create_programmer(prog="ecpprog")
         prog.load_bitstream(filename)
 
-# Main ---------------------------------------------------------------------------------------------
+#---------------------------------------------------------------------------------------------------
+# Build
+#---------------------------------------------------------------------------------------------------
 
 supported_boards = {
     # Xilinx
-    "arty":         Arty,
-    "sdi_mipi_bridge":     SDI_MIPI_Bridge,
+    "arty"                        : Arty,
+
+    # Lattice
+    "sdi_mipi_bridge"             : SDI_MIPI_Bridge,
 }
 
 def main():

--- a/make.py
+++ b/make.py
@@ -15,8 +15,6 @@ class Board:
     def __init__(self, soc_cls):
         self.soc_cls = soc_cls
         self.mmcm_freq = {}
-        self.bitstream_name=""
-        self.bitstream_ext=""
 
     def load(self, soc, filename):
         prog = soc.platform.create_programmer()
@@ -39,8 +37,6 @@ class Arty(Board):
             "i2s_rx" :  11.289e6,
             "i2s_tx" :  22.579e6,
         }
-        self.bitstream_name="digilent_arty"
-        self.bitstream_ext=".bit"
 
 #---------------------------------------------------------------------------------------------------
 # Lattice Boards
@@ -52,9 +48,7 @@ class SDI_MIPI_Bridge(Board):
     def __init__(self):
         from litex_boards.targets import antmicro_sdi_mipi_video_converter
         Board.__init__(self, antmicro_sdi_mipi_video_converter.BaseSoC)
-        self.bitstream_name="antmicro_sdi_mipi_video_converter"
-        self.bitstream_ext=".bit"
-    
+
     def load(self, soc, filename):
         prog = soc.platform.create_programmer(prog="ecpprog")
         prog.load_bitstream(filename)
@@ -139,8 +133,6 @@ def main():
                     soc.add_mmcm(board.mmcm_freq)
                 soc.add_i2s()
 
-        build_dir = os.path.join("build", board.bitstream_name)
-
         if args.build:
             builder = Builder(soc, **builder_argdict(args))
             if args.toolchain == "vivado":
@@ -152,7 +144,7 @@ def main():
             builder.build(**builder_kwargs, run=args.build)
 
         if args.load:
-            board.load(soc, filename=os.path.join(build_dir, "gateware", board.bitstream_name + board.bitstream_ext))
+            board.load(filename=builder.get_bitstream_filename(mode="sram"))
 
 if __name__ == "__main__":
     main()

--- a/make.py
+++ b/make.py
@@ -77,17 +77,17 @@ def main():
     parser.add_argument("--build", action="store_true", help="build bitstream")
     parser.add_argument("--variant", default=None, help="FPGA board variant")
     parser.add_argument("--load", action="store_true", help="load bitstream (to SRAM). set path to bitstream")
-    parser.add_argument("--with_ethernet", action="store_true", help="Enable ethernet (Arty target only)")
-    parser.add_argument("--with_i2s", action="store_true", help="Enable i2s (Arty target only)")
+    parser.add_argument("--with_ethernet", action="store_true", help="Enable Ethernet")
+    parser.add_argument("--with_i2s", action="store_true", help="Enable I2S")
     parser.add_argument("--sys-clk-freq", default=100e6, help="System clock frequency.")
-    parser.add_argument("--with_spi", action="store_true", help="Enable spi (Arty target only)")
-    parser.add_argument("--with_i2c", action="store_true", help="Enable i2c (Arty target only)")
-    parser.add_argument("--with_pwm", action="store_true", help="Enable pwm (Arty target only)")
-    parser.add_argument("--spi-data-width", type=int, default=8,      help="SPI data width (maximum transfered bits per xfer, Arty target only)")
-    parser.add_argument("--spi-clk-freq",   type=int, default=1e6,    help="SPI clock frequency (Arty target only)")
-    parser.add_argument("--with_mmcm", action="store_true", help="Enable mmcm (Arty target only)")
-    parser.add_argument("--local-ip", default="192.168.1.50", help="local IP address (Arty target only)")
-    parser.add_argument("--remote-ip", default="192.168.1.100", help="remote IP address of TFTP server (Arty target only)")
+    parser.add_argument("--with_spi", action="store_true", help="Enable SPI")
+    parser.add_argument("--with_i2c", action="store_true", help="Enable I2C")
+    parser.add_argument("--with_pwm", action="store_true", help="Enable PWM")
+    parser.add_argument("--spi-data-width", type=int, default=8,      help="SPI data width (maximum transfered bits per xfer)")
+    parser.add_argument("--spi-clk-freq",   type=int, default=1e6,    help="SPI clock frequency")
+    parser.add_argument("--with_mmcm", action="store_true", help="Enable mmcm")
+    parser.add_argument("--local-ip", default="192.168.1.50", help="local IP address")
+    parser.add_argument("--remote-ip", default="192.168.1.100", help="remote IP address of TFTP server")
     builder_args(parser)
     vivado_build_args(parser)
     oxide_args(parser)
@@ -116,22 +116,18 @@ def main():
 
         soc = SoCZephyr(board.soc_cls, **soc_kwargs)
 
-        if board_name == "arty":
-            if args.with_ethernet:
-                soc.add_eth(local_ip=args.local_ip, remote_ip=args.remote_ip)
-            if args.with_mmcm:
-                soc.add_mmcm(board.mmcm_freq)
-            if args.with_pwm:
-                soc.add_rgb_led()
-            if args.with_spi:
-                soc.add_spi(args.spi_data_width, args.spi_clk_freq)
-            if args.with_i2c:
-                soc.add_i2c()
-            if args.with_i2s:
-                if not args.with_mmcm:
-                    print("Adding mmcm implicitly, cause i2s core needs special clk signals")
-                    soc.add_mmcm(board.mmcm_freq)
-                soc.add_i2s()
+        if args.with_ethernet:
+            soc.add_eth(local_ip=args.local_ip, remote_ip=args.remote_ip)
+        if args.with_mmcm:
+            soc.add_mmcm(board.mmcm_freq)
+        if args.with_pwm:
+            soc.add_rgb_led()
+        if args.with_spi:
+            soc.add_spi(args.spi_data_width, args.spi_clk_freq)
+        if args.with_i2c:
+            soc.add_i2c()
+        if args.with_i2s:
+            soc.add_i2s()
 
         if args.build:
             builder = Builder(soc, **builder_argdict(args))

--- a/make.py
+++ b/make.py
@@ -101,6 +101,7 @@ def main():
     parser.add_argument("--variant", default=None, help="FPGA board variant")
     parser.add_argument("--load", action="store_true", help="load bitstream (to SRAM). set path to bitstream")
     parser.add_argument("--sys-clk-freq", default=100e6, help="System clock frequency.")
+    parser.add_argument("--spi-flash-init", default=None, help="path to the Zephyr image file")
     parser.add_argument("--spi-data-width", type=int, default=8,      help="SPI data width (maximum transfered bits per xfer)")
     parser.add_argument("--spi-clk-freq",   type=int, default=1e6,    help="SPI clock frequency")
     parser.add_argument("--local-ip", default="192.168.1.50", help="local IP address")
@@ -126,12 +127,15 @@ def main():
         soc_kwargs.update(board.soc_kwargs)
         soc_kwargs.update(toolchain=args.toolchain)
         soc_kwargs.update(with_jtagbone=False)
+        soc_kwargs.update(spi_flash_init=args.spi_flash_init)
 
         # SoC parameters ---------------------------------------------------------------------------
         if args.variant is not None:
             soc_kwargs.update(variant=args.variant)
         if args.sys_clk_freq is not None:
             soc_kwargs.update(sys_clk_freq=int(float(args.sys_clk_freq)))
+        if "spiflash" in board.soc_capabilities:
+            soc_kwargs.update(with_spi_flash=True)
 
         # SoC creation -----------------------------------------------------------------------------
         soc = SoCZephyr(board.soc_cls, **soc_kwargs)


### PR DESCRIPTION
This simply toggles the SPI feature on.

There need to be a minor adjustment on the Zephyr device tree.
Pull request in the relevant repos...

```
(litex-3.11) lap1$ ./make.py --board=lattice_crosslink_nx_evn --toolchain=oxide --with-spi-flash --csr-json=csr.json --toolchain=oxide --build
[...]
(litex-3.11) lap1$ ./make.py --board=lattice_crosslink_nx_evn --toolchain=oxide --load
[...]
IDCODE: 0x110f1043 (LIFCL-40)
NX Status Register: 0x0000051114800000
reset..
NX Status Register: 0x0000051114800e50
programming..
NX Status Register: 0x0000051100c00100
Bye.
(litex-3.11) lap1$ litex_term /dev/ttyUSB1

litex> mem_list
Available memory regions:
ROM       0x00000000 0xfa00
SRAM      0x10000000 0x4000
MAIN_RAM  0x40000000 0x10000
SPIFLASH  0x01000000 0x1000000
CSR       0xe0000000 0x10000

litex> boot 0x01000000
Executing booted program at 0x01000000

--============= Liftoff! ===============--


uart:~$ device list
devices:
- serial@e0001800 (READY)
- gpio@e0006000 (READY)
- gpio@e0005800 (READY)
uart:~$
```

And a finish line photo:
![2023-08-18-104858_1050x1001_scrot](https://github.com/litex-hub/zephyr-on-litex-vexriscv/assets/55351021/61781759-4e9a-4af0-a38e-6d5f2bed77b5)


Related: #12